### PR TITLE
PHP prefers ; comments to # comments

### DIFF
--- a/.sandstorm/service-config/php.conf/phabricator.conf.ini
+++ b/.sandstorm/service-config/php.conf/phabricator.conf.ini
@@ -1,5 +1,5 @@
 always_populate_raw_post_data = -1
 post_max_size = "512M"
-#opcache.validate_timestamps = 0
-#opcache.revalidate_freq = 0
+;opcache.validate_timestamps = 0
+;opcache.revalidate_freq = 0
 date.timezone = "UTC"


### PR DESCRIPTION
Before this patch, on grain launch, I see warnings in the grain log:

```
[13-Sep-2016 22:07:08] NOTICE: PHP message: PHP Deprecated:  Comments starting with '#' are deprecated in /etc/php5/fpm/conf.d/phabricator.conf.ini on line 3 in Unknown on line 0
```
